### PR TITLE
Prompt user to restart after a successful installation

### DIFF
--- a/Install360Controller/Install360Controller.pkgproj
+++ b/Install360Controller/Install360Controller.pkgproj
@@ -596,7 +596,7 @@
 				<key>AUTHENTICATION</key>
 				<integer>1</integer>
 				<key>CONCLUSION_ACTION</key>
-				<integer>0</integer>
+				<integer>2</integer>
 				<key>IDENTIFIER</key>
 				<string>com.mice.pkg.Xbox360controller</string>
 				<key>NAME</key>


### PR DESCRIPTION
I've set the installer to prompt the user to restart after a successful installation.
Fixes #11 
