### PR TITLE
Fixing driver for the Hori Real Arcade Pro EX

### DIFF
--- a/360Controller/_60Controller.cpp
+++ b/360Controller/_60Controller.cpp
@@ -422,15 +422,16 @@ bool Xbox360Peripheral::start(IOService *provider)
 		goto fail;
 	}
 	// Configure ChatPad
-		// Send 'configuration'
+	// Send 'configuration'
 	SendInit(0xa30c, 0x4423);
 	SendInit(0x2344, 0x7f03);
 	SendInit(0x5839, 0x6832);
-		// Set 'switch'
-    if ((!SendSwitch(false)) || (!SendSwitch(true)) || (!SendSwitch(false)))
+	// Set 'switch'
+    if ((!SendSwitch(false)) || (!SendSwitch(true)) || (!SendSwitch(false))) {
         // Commenting goto fail fixes the driver for the Hori Real Arcade Pro EX
         //goto fail;
-		// Begin toggle
+	}
+	// Begin toggle
 	serialHeard = false;
 	serialActive = false;
 	serialToggle = false;


### PR DESCRIPTION
the goto fail statement in the _60Controller.cpp line after the several SendInit calls was causing the driver to fail for the Hori Real Arcade Pro EX. Perhaps none of the control requests sent are understood by the EX. In any case, commenting this line out fixed it. 

I connected my Wireless Receiver and my standard XBox 360 Controller continued to work. Please let me know if other devices still work with this fix. I'd love to get this driver working for the rest of the folks who have this stick. 
