### PR TITLE
Removed calls of Pref360ControlPref -updateLED

### DIFF
--- a/Pref360Control/Pref360ControlPref.m
+++ b/Pref360Control/Pref360ControlPref.m
@@ -369,7 +369,6 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
     if(registryEntry==0) return;
     [self testMotorsLarge:0 small:0];
     [self testMotorsCleanUp];
-    [self updateLED:0x00];
     if (hidQueue) {
         CFRunLoopSourceRef eventSource;
         
@@ -564,8 +563,7 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
     // Enable GUI components
     [self inputEnable:YES];
     // Set device capabilities
-    // Set LED and FF motor control
-    [self updateLED:0x0a];
+    // Set FF motor control
     [self testMotorsInit];
     [self testMotorsLarge:0 small:0];
     largeMotor=0;


### PR DESCRIPTION
The calls made to -updateLED were erroneous, and were causing strange behavior. This should fix issue #35. The method -updateLED can be deleted now as it's not used, but it wasn't deleted here.
