### PR TITLE
Update version number label to beta 4

### DIFF
--- a/Pref360Control/en.lproj/Pref360ControlPref.xib
+++ b/Pref360Control/en.lproj/Pref360ControlPref.xib
@@ -990,7 +990,7 @@ Due to some internal limitations, you need to connect your device once to be abl
                                                                                 </paragraphStyle>
                                                                             </attributes>
                                                                         </fragment>
-                                                                        <fragment content="Version 0.15 (beta 3) unofficial">
+                                                                        <fragment content="Version 0.15 (beta 4) unofficial">
                                                                             <attributes>
                                                                                 <font key="NSFont" size="12" name="Helvetica"/>
                                                                                 <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural">


### PR DESCRIPTION
Fixing the about panel still showing 0.15 (beta 3) in the beta 4 release.