### PR TITLE
Add Afterglow Prismatic Controller for Xbox One

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -40,6 +40,26 @@
 			<key>idVendor</key>
 			<integer>3695</integer>
 		</dict>
+		<key>AfterglowPrismaticOne</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>313</integer>
+			<key>idVendor</key>
+			<integer>3695</integer>
+		</dict>
 		<key>ArcadeGameStick</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
I bought an Afterglow Prismatic controller a few days ago and discovered that this driver didn't support it. I pulled the vendor and product IDs from System Information and it seems to work quite well. It does rumble when just barely pressing in LT and RT but the rumble stops after pressing the triggers in further.

I've been testing with Euro Truck Simulator 2 and it seems to be working as I expect.