### PR TITLE
HORI Real Arcade Pro.EX Premium VLX Support

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -1691,6 +1691,26 @@
 			<key>idVendor</key>
 			<integer>7085</integer>
 		</dict>
+		<key>HORI Real Arcade Pro.EX Premium VLX</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>62726</integer>
+			<key>idVendor</key>
+			<integer>7085</integer>
+		</dict>
 		<key>RazerAtrox</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
This commit adds support for the HORI Real Arcade Pro.EX Premium VLX stick.
(Released in Japan in 2010, HORI Store exclusive)

http://www.hori.jp/products/multi/controller/rap_premium_vlx/360/