### PR TITLE
Change product string for an Xbox One pad pretending to be a 360 pad

### DIFF
--- a/360Controller/Controller.cpp
+++ b/360Controller/Controller.cpp
@@ -673,7 +673,7 @@ OSDefineMetaClassAndStructors(XboxOnePretend360Class, XboxOneControllerClass)
 
 OSString* XboxOnePretend360Class::newProductString() const
 {
-    return OSString::withCString("Xbox One Wired Controller (Xbox 360)");
+    return OSString::withCString("Xbox 360 Wired Controller");
 }
 
 OSNumber* XboxOnePretend360Class::newProductIDNumber() const

--- a/Pref360Control/DeviceItem.h
+++ b/Pref360Control/DeviceItem.h
@@ -28,7 +28,7 @@
 #include <ForceFeedback/ForceFeedback.h>
 
 @interface DeviceItem : NSObject
-@property (strong, readonly) NSString *name;
+@property (strong, readonly) NSString *displayName;
 @property (readonly) io_service_t rawDevice;
 @property (readonly) FFDeviceObjectReference ffDevice;
 @property (readonly) IOHIDDeviceInterface122 **hidDevice;

--- a/Pref360Control/DeviceItem.h
+++ b/Pref360Control/DeviceItem.h
@@ -26,9 +26,11 @@
 #include <IOKit/hid/IOHIDLib.h>
 #include <IOKit/hid/IOHIDKeys.h>
 #include <ForceFeedback/ForceFeedback.h>
+#import "Pref360ControlPref.h"
 
 @interface DeviceItem : NSObject
 @property (strong, readonly) NSString *displayName;
+@property (readonly) ControllerType controllerType;
 @property (readonly) io_service_t rawDevice;
 @property (readonly) FFDeviceObjectReference ffDevice;
 @property (readonly) IOHIDDeviceInterface122 **hidDevice;

--- a/Pref360Control/DeviceItem.m
+++ b/Pref360Control/DeviceItem.m
@@ -140,7 +140,10 @@ static ControllerType GetControllerType(io_service_t device)
 - (NSString *)displayName {
     if (self.deviceName == nil)
         return @"Generic Controller";
-    return self.deviceName;
+    else if (self.controllerType == XboxOnePretend360Controller)
+        return @"Xbox One Controller (Xbox 360)";
+    else
+        return self.deviceName;
 }
 
 @end

--- a/Pref360Control/DeviceItem.m
+++ b/Pref360Control/DeviceItem.m
@@ -37,14 +37,56 @@ static NSString* GetDeviceName(io_service_t device)
     return deviceName;
 }
 
+static ControllerType GetControllerType(io_service_t device)
+{
+    io_service_t parent;
+    CFMutableDictionaryRef serviceProperties;
+    
+    // Check for the DeviceData dictionary in device
+    if (IORegistryEntryCreateCFProperties(device, &serviceProperties, kCFAllocatorDefault, kNilOptions) == KERN_SUCCESS)
+    {
+        NSDictionary *properties = CFBridgingRelease(serviceProperties);
+        NSDictionary *deviceData = properties[@"DeviceData"];
+        
+        if (deviceData != nil)
+        {
+            NSNumber *controllerType = deviceData[@"ControllerType"];
+            if (controllerType != nil)
+                return (ControllerType)[controllerType intValue];
+        }
+    }
+    
+    // Check for the DeviceData dictionary in the device's parent
+    if (IORegistryEntryGetParentEntry(device, kIOServicePlane, &parent) == KERN_SUCCESS)
+    {
+        if(IORegistryEntryCreateCFProperties(parent, &serviceProperties, kCFAllocatorDefault, kNilOptions) == KERN_SUCCESS)
+        {
+            NSDictionary *properties = CFBridgingRelease(serviceProperties);
+            NSDictionary *deviceData = properties[@"DeviceData"];
+            
+            if (deviceData != nil)
+            {
+                NSNumber *controllerType = deviceData[@"ControllerType"];
+                if (controllerType != nil)
+                    return (ControllerType)[controllerType intValue];
+            }
+        }
+    }
+    
+    NSLog(@"Error: couldn't find ControllerType");
+    return Xbox360Controller;
+}
+
 @interface DeviceItem ()
 @property (strong, readwrite) NSString *deviceName;
+@property (readwrite) ControllerType controllerType;
 @property (readwrite) io_service_t rawDevice;
 @property (readwrite) FFDeviceObjectReference ffDevice;
 @property (readwrite) IOHIDDeviceInterface122 **hidDevice;
 @end
 
 @implementation DeviceItem
+@synthesize controllerType = controllerType;
 @synthesize rawDevice = deviceHandle;
 @synthesize ffDevice = forceFeedback;
 @synthesize hidDevice = interface;
@@ -69,6 +111,7 @@ static NSString* GetDeviceName(io_service_t device)
         FFCreateDevice(device, &forceFeedback);
         self.rawDevice = device;
         self.deviceName = GetDeviceName(device);
+        self.controllerType = GetControllerType(device);
     }
     return self;
 }

--- a/Pref360Control/DeviceItem.m
+++ b/Pref360Control/DeviceItem.m
@@ -38,14 +38,13 @@ static NSString* GetDeviceName(io_service_t device)
 }
 
 @interface DeviceItem ()
-@property (strong, readwrite) NSString *name;
+@property (strong, readwrite) NSString *deviceName;
 @property (readwrite) io_service_t rawDevice;
 @property (readwrite) FFDeviceObjectReference ffDevice;
 @property (readwrite) IOHIDDeviceInterface122 **hidDevice;
 @end
 
 @implementation DeviceItem
-@synthesize name = deviceName;
 @synthesize rawDevice = deviceHandle;
 @synthesize ffDevice = forceFeedback;
 @synthesize hidDevice = interface;
@@ -69,7 +68,7 @@ static NSString* GetDeviceName(io_service_t device)
         forceFeedback = 0;
         FFCreateDevice(device, &forceFeedback);
         self.rawDevice = device;
-        self.name = GetDeviceName(device);
+        self.deviceName = GetDeviceName(device);
     }
     return self;
 }
@@ -93,6 +92,12 @@ static NSString* GetDeviceName(io_service_t device)
         (*interface)->Release(interface);
     if (forceFeedback)
         FFReleaseDevice(forceFeedback);
+}
+
+- (NSString *)displayName {
+    if (self.deviceName == nil)
+        return @"Generic Controller";
+    return self.deviceName;
 }
 
 @end

--- a/Pref360Control/Pref360ControlPref.m
+++ b/Pref360Control/Pref360ControlPref.m
@@ -434,6 +434,7 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
         device = [item hidDevice];
         ffDevice = [item ffDevice];
         registryEntry = [item rawDevice];
+        controllerType = [item controllerType];
     }
 
     if((*device)->copyMatchingElements(device,NULL,&CFelements)!=kIOReturnSuccess) {
@@ -603,7 +604,9 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
 
             if(CFDictionaryGetValueIfPresent(dict,CFSTR("ControllerType"),(void*)&intValue)) {
                 NSNumber *num = (__bridge NSNumber *)intValue;
-                controllerType = (ControllerType)[num integerValue];
+                ControllerType controllerTypePrefs = (ControllerType)[num integerValue];
+                if (controllerTypePrefs != controllerType)
+                    NSLog(@"ControllerType from prefs was %d, expected %d", (int)controllerTypePrefs, (int)controllerType);
             } else NSLog(@"No value for ControllerType\n");
             if(CFDictionaryGetValueIfPresent(dict,CFSTR("RumbleType"),(void*)&intValue)) {
                 NSNumber *num = (__bridge NSNumber *)intValue;
@@ -902,6 +905,15 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
         [_rightStickInvertX setState:[_rightStickInvertXAlt state]];
         [_rightStickInvertY setState:[_rightStickInvertYAlt state]];
     }
+    
+    BOOL pretend360 = ([_pretend360Button state] == NSOnState);
+    if (controllerType == XboxOneController || controllerType == XboxOnePretend360Controller)
+    {
+        if (pretend360)
+            controllerType = XboxOnePretend360Controller;
+        else
+            controllerType = XboxOneController;
+    }
 
     // Create dictionary
     NSDictionary *dict = @{@"InvertLeftX": @((BOOL)([_leftStickInvertX state]==NSOnState)),
@@ -932,7 +944,7 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
                            @"BindingX": @((UInt8)([MyWhole360ControllerMapper mapping][13])),
                            @"BindingY": @((UInt8)([MyWhole360ControllerMapper mapping][14])),
                            @"SwapSticks": @((BOOL)([_swapSticks state]==NSOnState)),
-                           @"Pretend360": @((BOOL)([_pretend360Button state]==NSOnState))};
+                           @"Pretend360": @((BOOL)pretend360)};
 
     // Set property
     IORegistryEntrySetCFProperties(registryEntry, (__bridge CFTypeRef)(dict));

--- a/Pref360Control/Pref360ControlPref.m
+++ b/Pref360Control/Pref360ControlPref.m
@@ -763,9 +763,7 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
         DeviceItem *item = [DeviceItem allocateDeviceItemForDevice:hidDevice];
         if (item == nil) continue;
         // Add to item
-        NSString *name = item.name;
-        if (name == nil)
-            name = @"Generic Controller";
+        NSString *name = item.displayName;
         [_deviceList addItemWithTitle:[NSString stringWithFormat:@"%i: %@ (%@)", ++count, name, deviceWireless ? @"Wireless" : @"Wired"]];
         [_deviceListBinding addItemWithTitle:[NSString stringWithFormat:@"%i: %@ (%@)", count, name, deviceWireless ? @"Wireless" : @"Wired"]];
         [_deviceListAdvanced addItemWithTitle:[NSString stringWithFormat:@"%i: %@ (%@)", count, name, deviceWireless ? @"Wireless" : @"Wired"]];


### PR DESCRIPTION
At least one game I play had an issue with my new Xbox One pad, with the "pretend to be an Xbox 360 controller" option in the Preference Pane enabled (namely, [Brawlhalla](http://store.steampowered.com/app/291550/), which works with my 360 pad, and actually works with the Xbox One pad as well when this option is *disabled*). Currently, the `XboxOnePretend360Class::newProductString()` method returns "Xbox One Wired Controller (Xbox 360)" as the product string. Changing the string to "Xbox 360 Wired Controller" fixed this particular issue for me.

One minor thing to note with this change is that, in the Preference Pane, the Xbox One controller will be listed as "Xbox 360 Wired Controller (Wired)" on the dropdown when "pretend to be an Xbox 360 controller" is enabled:

!["pretend to be an Xbox 360 controller" option enabled](https://cloud.githubusercontent.com/assets/1362179/14764654/f88abe12-0974-11e6-855c-7f47755c93eb.png)

...but there are no other user-facing differences beyond that, AFAICT.