### PR TITLE
Fix remapping for wireless 360 controllers

### DIFF
--- a/Wireless360Controller/Wireless360Controller.cpp
+++ b/Wireless360Controller/Wireless360Controller.cpp
@@ -55,6 +55,16 @@ bool Wireless360Controller::init(OSDictionary *propTable)
     deadzoneLeft = deadzoneRight = 0;
     relativeLeft = relativeRight = false;
     readSettings();
+    // Bindings
+    noMapping = true;
+    for (int i = 0; i < 11; i++)
+    {
+        mapping[i] = i;
+    }
+    for (int i = 12; i < 16; i++)
+    {
+        mapping[i-1] = i;
+    }
 
     // Done
     return res;
@@ -123,6 +133,17 @@ void Wireless360Controller::readSettings(void)
     if (number != NULL) mapping[14] = number->unsigned32BitValue();
     value = OSDynamicCast(OSBoolean, dataDictionary->getObject("SwapSticks"));
     if (value != NULL) swapSticks = value->getValue();
+    
+    noMapping = true;
+    UInt8 normalMapping[15] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15 };
+    for (int i = 0; i < 15; i++)
+    {
+        if (normalMapping[i] != mapping[i])
+        {
+            noMapping = false;
+            break;
+        }
+    }
 #if 0
     IOLog("Xbox360ControllerClass preferences loaded:\n  invertLeft X: %s, Y: %s\n   invertRight X: %s, Y:%s\n  deadzone Left: %d, Right: %d\n\n",
             invertLeftX?"True":"False",invertLeftY?"True":"False",
@@ -309,7 +330,8 @@ void Wireless360Controller::remapAxes(void *buffer)
 void Wireless360Controller::receivedHIDupdate(unsigned char *data, int length)
 {
     fiddleReport(data, length);
-//    remapButtons(data);
+    if (!noMapping)
+        remapButtons(data);
     if (swapSticks)
         remapAxes(data);
     super::receivedHIDupdate(data, length);

--- a/Wireless360Controller/Wireless360Controller.h
+++ b/Wireless360Controller/Wireless360Controller.h
@@ -60,6 +60,7 @@ protected:
 
     bool swapSticks;
     UInt8 mapping[15];
+    bool noMapping = true;
 
 private:
     void fiddleReport(unsigned char *data, int length);


### PR DESCRIPTION
This PR re-enables button remapping for wireless 360 controllers. I believe that this fixes the issues described in #141 and #142 (if someone more familiar with these issues could chime in and test this, I'd appreciate it!)

The problem was the `mapping` field in `Wireless360Controller`, which was never explicitly initialized. This caused all buttons to map to D-pad up until the Preference Pane was opened. The fix was to copy the logic from [`Xbox360Peripheral::init()`](https://github.com/360Controller/360Controller/blob/b87af7ce0076ddd2bfee76b04cd7d90f16d335e6/360Controller/_60Controller.cpp#L327-L335) (although it might be a good idea to refactor these classes to reduce duplication).

AFAICT, this issue is actually unrelated to #67 (which I'm still trying to work on)