### PR TITLE
Fix issues with "Binding" Preference Pane tab

### DIFF
--- a/Pref360Control/MyWhole360ControllerMapper.h
+++ b/Pref360Control/MyWhole360ControllerMapper.h
@@ -14,7 +14,8 @@
 
 @property BOOL isMapping;
 
-- (void)runMapperWithButton:(NSButton *)button  andOwner:(Pref360ControlPref *)pref;
+- (void)runMapperWithButton:(NSButton *)button andOwner:(Pref360ControlPref *)pref;
+- (void)resetWithOwner:(Pref360ControlPref *)pref;
 - (void)buttonPressedAtIndex:(int)index;
 + (UInt8 *)mapping;
 

--- a/Pref360Control/MyWhole360ControllerMapper.h
+++ b/Pref360Control/MyWhole360ControllerMapper.h
@@ -15,6 +15,7 @@
 @property BOOL isMapping;
 
 - (void)runMapperWithButton:(NSButton *)button andOwner:(Pref360ControlPref *)pref;
+- (void)cancelMappingWithButton:(NSButton *)button andOwner:(Pref360ControlPref *)pref;
 - (void)resetWithOwner:(Pref360ControlPref *)pref;
 - (void)buttonPressedAtIndex:(int)index;
 + (UInt8 *)mapping;

--- a/Pref360Control/MyWhole360ControllerMapper.m
+++ b/Pref360Control/MyWhole360ControllerMapper.m
@@ -60,8 +60,8 @@ static UInt8 previousMapping[15];
     pref = prefPref;
     remappingButton = button;
     [self saveCurrentMapping];
-//    [self resetMapping];
-//    [pref changeSetting:nil];
+    [self resetMapping];
+    [pref changeSetting:nil];
     [self startMapping];
 }
 

--- a/Pref360Control/MyWhole360ControllerMapper.m
+++ b/Pref360Control/MyWhole360ControllerMapper.m
@@ -156,7 +156,14 @@ static UInt8 mapping[15];
     }
 }
 
+- (void)resetWithOwner:(Pref360ControlPref *)prefPref {
+    pref = prefPref;
+    [self reset];
+}
+
 - (void)reset {
+    if (pref == nil)
+        NSLog(@"Unable to reset remapping (pref is nil)");
     [super reset];
     _isMapping = NO;
     [self resetMapping];

--- a/Pref360Control/MyWhole360ControllerMapper.m
+++ b/Pref360Control/MyWhole360ControllerMapper.m
@@ -18,6 +18,7 @@
 }
 
 static UInt8 mapping[15];
+static UInt8 previousMapping[15];
 
 + (UInt8 *)mapping
 {
@@ -43,16 +44,33 @@ static UInt8 mapping[15];
     [pref changeSetting:nil];
 }
 
+- (void)saveCurrentMapping {
+    for (int i = 0; i < 15; i++) {
+        previousMapping[i] = mapping[i];
+    }
+}
+
+- (void)restorePreviousMapping {
+    for (int i = 0; i < 15; i++) {
+        mapping[i] = previousMapping[i];
+    }
+}
+
 - (void)runMapperWithButton:(NSButton *)button andOwner:(Pref360ControlPref *)prefPref {
     pref = prefPref;
     remappingButton = button;
+    [self saveCurrentMapping];
 //    [self resetMapping];
 //    [pref changeSetting:nil];
     [self startMapping];
 }
 
 - (void)cancelMappingWithButton:(NSButton *)button andOwner:(Pref360ControlPref *)prefPref {
-    [self resetWithOwner:prefPref];
+    pref = prefPref;
+    remappingButton = button;
+    
+    [self restorePreviousMapping];
+    [self stopMapping];
 }
 
 - (int)realignButtonToByte:(int)index {

--- a/Pref360Control/MyWhole360ControllerMapper.m
+++ b/Pref360Control/MyWhole360ControllerMapper.m
@@ -51,6 +51,10 @@ static UInt8 mapping[15];
     [self startMapping];
 }
 
+- (void)cancelMappingWithButton:(NSButton *)button andOwner:(Pref360ControlPref *)prefPref {
+    [self resetWithOwner:prefPref];
+}
+
 - (int)realignButtonToByte:(int)index {
     if (index == 0) return 12;
     if (index == 1) return 13;

--- a/Pref360Control/MyWhole360ControllerMapper.m
+++ b/Pref360Control/MyWhole360ControllerMapper.m
@@ -24,14 +24,31 @@ static UInt8 mapping[15];
     return mapping;
 }
 
+- (void)startMapping
+{
+    currentMappingIndex = 0;
+    _isMapping = YES;
+    [self setUpPressed:YES];
+}
+
+- (void)stopMapping
+{
+    [super reset];
+    currentMappingIndex = 0;
+    _isMapping = NO;
+    if (remappingButton != nil)
+        [remappingButton setState:NSOffState];
+    [pref changeSetting:nil];
+    [[BindingTableView tableView] reloadData];
+    [pref changeSetting:nil];
+}
+
 - (void)runMapperWithButton:(NSButton *)button andOwner:(Pref360ControlPref *)prefPref {
     pref = prefPref;
     remappingButton = button;
 //    [self resetMapping];
 //    [pref changeSetting:nil];
-    currentMappingIndex = 0;
-    _isMapping = YES;
-    [self setUpPressed:YES];
+    [self startMapping];
 }
 
 - (int)realignButtonToByte:(int)index {
@@ -57,13 +74,8 @@ static UInt8 mapping[15];
     mapping[currentMappingIndex] = [self realignButtonToByte:index];
     currentMappingIndex++;
     [self setButtonAtIndex:currentMappingIndex];
-    if (currentMappingIndex == 15) {
-        _isMapping = NO;
-        currentMappingIndex = 0;
-        [remappingButton setState:NSOffState];
-        [[BindingTableView tableView] reloadData];
-        [pref changeSetting:nil];
-    }
+    if (currentMappingIndex == 15)
+        [self stopMapping];
 }
 
 - (void)setButtonAtIndex:(int)index {
@@ -164,13 +176,8 @@ static UInt8 mapping[15];
 - (void)reset {
     if (pref == nil)
         NSLog(@"Unable to reset remapping (pref is nil)");
-    [super reset];
-    _isMapping = NO;
     [self resetMapping];
-    [remappingButton setState:NSOffState];
-    [pref changeSetting:nil];
-    [[BindingTableView tableView] reloadData];
-    [pref changeSetting:nil];
+    [self stopMapping];
 }
 
 - (void)awakeFromNib {

--- a/Pref360Control/Pref360ControlPref.m
+++ b/Pref360Control/Pref360ControlPref.m
@@ -1125,7 +1125,7 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
     if (![_wholeControllerMapper isMapping])
         [_wholeControllerMapper runMapperWithButton:_remappingButton andOwner:self];
     else
-        [_wholeControllerMapper resetWithOwner:self];
+        [_wholeControllerMapper cancelMappingWithButton:_remappingButton andOwner:self];
 }
 
 - (IBAction)resetRemappingPressed:(id)sender {

--- a/Pref360Control/Pref360ControlPref.m
+++ b/Pref360Control/Pref360ControlPref.m
@@ -1125,12 +1125,12 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
     if (![_wholeControllerMapper isMapping])
         [_wholeControllerMapper runMapperWithButton:_remappingButton andOwner:self];
     else
-        [_wholeControllerMapper reset];
+        [_wholeControllerMapper resetWithOwner:self];
 }
 
 - (IBAction)resetRemappingPressed:(id)sender {
     [_remappingButton setState:NSOffState];
-    [_wholeControllerMapper reset];
+    [_wholeControllerMapper resetWithOwner:self];
 }
 
 - (IBAction)pretend360Checked:(id)sender {


### PR DESCRIPTION
Fixes a number of minor issues when remapping keys under the "Binding" tab of the Preference Pane:

- Clicking "Reset Mapping" would do nothing if the "Start Remapping" button hadn't been pressed (the `pref` field of `MyWhole360ControllerMapper ` was `nil` until `runMapperWithButton:andOwner:` was called)
- Clicking "Start Remapping", then "Cancel Remapping" would reset the button mappings to the default (not the user's previous button mapping)
- Clicking "Start Remapping" and mapping e.g. A to B and B to X, then clicking "Start Remapping" and trying to map X to A would actually result in mapping X to B (i.e. bindings were not reset before accepting new bindings)