### PR TITLE
Add 3rd party XBOX Logitech Thunderpad id

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -571,6 +571,26 @@
 			<key>idVendor</key>
 			<integer>1133</integer>
 		</dict>
+		<key>LogitechTHUNDERPAD</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>51848</integer>
+			<key>idVendor</key>
+			<integer>1133</integer>
+		</dict>
 		<key>GuitarHero</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
This is the official Logitech THUNDERPAD first generation XBOX 3rd party controller with USB wiring adapter, tested succesfull on OSX 10.12.6.

P/N:863230-0000
M/N: G-X3B9

https://www.amazon.com/Logitech-Thunderpad-Controller-for-Xbox/dp/B00009OYAR