### PR TITLE
add Xbox One NFL Face Off device id

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -1951,6 +1951,26 @@
 			<key>idVendor</key>
 			<integer>3695</integer>
 		</dict>
+		<key>PDPNFLFaceOff</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>352</integer>
+			<key>idVendor</key>
+			<integer>3695</integer>
+		</dict>
 		<key>PDPEASports</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
[Device](https://www.amazon.com/PDP-Official-Face-Off-Controller-Xbox-Windows/dp/B01GVJURHO)

```
NFL Official Face-Off Wired Controller for Xbox One:

  Product ID:	0x0160
  Vendor ID:	0x0e6f
  Version:	4.60
  Serial Number:	000003265D865D08
  Speed:	Up to 12 Mb/sec
  Manufacturer:	Performance Designed Products
  Location ID:	0x14610000 / 9
  Current Available (mA):	500
  Extra Operating Current (mA):	0
```