### PR TITLE
Added new Atplay controller

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -20,7 +20,7 @@
 	<string>${CURRENT_PROJECT_VERSION}</string>
 	<key>IOKitPersonalities</key>
 	<dict>
-		<key>AplayController</key>
+		<key>AtPlayController1</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
 			<string>com.mice.driver.Xbox360Controller</string>
@@ -37,6 +37,26 @@
 			<string>IOUSBDevice</string>
 			<key>idProduct</key>
 			<integer>64251</integer>
+			<key>idVendor</key>
+			<integer>9414</integer>
+		</dict>
+		<key>AtPlayController2</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>64250</integer>
 			<key>idVendor</key>
 			<integer>9414</integer>
 		</dict>


### PR DESCRIPTION
fixes issue #521 

Also renamed "aplay" into "atplay" since the website is "atplayaccessories.com"

This has been tested by modifying the Info.plist of an older installed driver in place and the controller works, but I couldn't manage to get the build environment working, so that's not tested there.