### PR TITLE
Add support for HORI RAP V Hayabusa for Nintendo Switch (NSW-006)

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -853,6 +853,26 @@
 			<key>idVendor</key>
 			<integer>3853</integer>
 		</dict>
+		<key>HoriRAPVHayabusaSwitch</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>216</integer>
+			<key>idVendor</key>
+			<integer>3853</integer>
+		</dict>
 		<key>HoriRAPVKai360</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
I've confirmed this arcade stick works great with the patched 360Controller.