### PR TITLE
Feat : Added support for Stealth Series Phantom

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -2013,6 +2013,26 @@
 			<key>idVendor</key>
 			<integer>3695</integer>
 		</dict>
+		<key>PDPStealthPhantomBlack</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>676</integer>
+			<key>idVendor</key>
+			<integer>3695</integer>
+		</dict>
 		<key>PDPTitanfall2</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
```
PDP Wired Controller for Xbox One - Stealth Series | Phantom Black:

  Product ID:	0x02a4
  Vendor ID:	0x0e6f
  Version:	1.0f
  Serial Number:	00003DB336CACEB5
  Speed:	Up to 12 Mb/sec
  Manufacturer:	Performance Designed Products
  Location ID:	0x14510000 / 11
  Current Available (mA):	500
  Extra Operating Current (mA):	0

```