### PR TITLE
Add Hori Real Arcade Pro V Hayabusa for Nintendo Switch.

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -873,6 +873,26 @@
 			<key>idVendor</key>
 			<integer>9414</integer>
 		</dict>
+		<key>HoriRAPVHayabusaSwitch</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>216</integer>
+			<key>idVendor</key>
+			<integer>3853</integer>
+		</dict>
 		<key>HoriRAPVKaiXboxOne</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
```
Real Arcade Pro S:

  Product ID:	0x00d8
  Vendor ID:	0x0f0d  (HORI CO., LTD.)
  Version:	5.72
  Serial Number:	KC-8259 V101
  Speed:	Up to 12 Mb/sec
  Manufacturer:	HORI CO.,LTD.
  Location ID:	0x14100000 / 4
  Current Available (mA):	500
  Extra Operating Current (mA):	0
```