### PR TITLE
Fix issue #635: force to use the old HFS+ filesystem in DMG creation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ fi
 cd Install360Controller
 packagesbuild -v Install360Controller.pkgproj
 mv build 360ControllerInstall
-hdiutil create -srcfolder 360ControllerInstall -format UDZO ../build/360ControllerInstall.dmg
+hdiutil create -srcfolder 360ControllerInstall -fs HFS+ -format UDZO ../build/360ControllerInstall.dmg
 mv 360ControllerInstall build
 cd ..
 echo "** File contents **"


### PR DESCRIPTION
New DMG images are created with APFS filesystem by default. Force to use the old HFS+ filesystem for compatibility reasons with old macOS versions.