### PR TITLE
Update installer texts

### DIFF
--- a/Install360Controller/Text/Readme.rtf
+++ b/Install360Controller/Text/Readme.rtf
@@ -12,8 +12,8 @@
 \pard\pardeftab720\sa283
 
 \b0\fs24 \cf0 This driver supports the
-\b Microsoft Xbox 360 controller, Original Xbox Controller, Xbox One Controller
-\b0  and various licensed third party controllers from brands like Hori, MadCatz, Logitech, etc. Including access to rumble motors and LEDs, on the Mac OS X platform. It includes a plugin for the Apple Force Feedback Framework so some games will be able to activate them, along with a Preference Pane with which allows you to test everything is installed correctly. Both wire controllers connected via USB, and wireless 360 controllers connected via the Wireless Gaming Receiver for Windows, are supported.\
+\b  Microsoft Xbox 360 controller, Original Xbox Controller, Xbox One Controller
+\b0 , and various licensed third party controllers from brands like Hori, MadCatz, Logitech, etc. Including access to rumble motors and LEDs, on the macOS platform. It includes a plugin for the Apple Force Feedback Framework so some games will be able to activate them, along with a Preference Pane with which allows you to test everything is installed correctly. Both wire controllers connected via USB and Bluetooth Xbox One S controllers. Wireless 360 controllers, connected via the Wireless Gaming Receiver for Windows, are NOT supported.\
 This project is a fork of the {\field{\*\fldinst{HYPERLINK "http://tattiebogle.net/index.php/ProjectRoot/Xbox360Controller"}}{\fldrslt \cf2 \ul \ulc0 Xbox360Controller project}} originally created by Colin Munro, and includes hard work from {\field{\*\fldinst{HYPERLINK "https://github.com/d235j/"}}{\fldrslt d235j}} (who forked the project and fixed Force Feedback), {\field{\*\fldinst{HYPERLINK "https://github.com/MaddTheSane"}}{\fldrslt C.W. Betts}} (dozens of improvements and fixes!), {\field{\*\fldinst{HYPERLINK "https://github.com/FranticRain"}}{\fldrslt FranticRain}} (Xbox One Controller support and other improvements), {\field{\*\fldinst{HYPERLINK "https://github.com/kasbert"}}{\fldrslt kasbert}} (Original Xbox Controller Support), {\field{\*\fldinst{HYPERLINK "https://github.com/Pyroh"}}{\fldrslt Pyroh}} (User Interface overhaul), {\field{\*\fldinst{HYPERLINK "https://github.com/RodrigoCard"}}{\fldrslt RodrigoCard}} (kext sign and some scripts) and others (please forgive us if we forgot to include someone).\
 \pard\pardeftab720\sb200\sa120
 
@@ -27,7 +27,7 @@ If you are interested in installing as a developer please see below.\
 \b\fs36 \cf0 Usage\
 \pard\pardeftab720\sa283
 
-\b0\fs24 \cf0 The driver exposes a standard game pad with a number of standard controls, so any game that supports gaming devices should work. In some cases this may need an update from the manufacturer of the game or a patched version. The Preference Pane uses the standard Mac OS X Frameworks for accessing HID devices and accessing Force Feedback capabilities, so should be a good test that the installation is functional.\
+\b0\fs24 \cf0 The driver exposes a standard game pad with a number of standard controls, so any game that supports gaming devices should work. In some cases this may need an update from the manufacturer of the game or a patched version. The Preference Pane uses the standard macOS Frameworks for accessing HID devices and accessing Force Feedback capabilities, so should be a good test that the installation is functional.\
 \pard\pardeftab720\sb200\sa120
 
 \b\fs36 \cf0 Developer info\

--- a/Install360Controller/Text/Welcome.rtf
+++ b/Install360Controller/Text/Welcome.rtf
@@ -40,9 +40,10 @@
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 
 \b0\fs24 \cf0 Version 0.16.7\
-Copyright (C) 2005-2013 Colin Munro\
+Copyright \'a9 2005\'962013 Colin Munro\
+Copyright \'a9 2013\'962018 {\field{\*\fldinst{HYPERLINK "https://github.com/360Controller/360Controller/graphs/contributors"}}{\fldrslt 360Controller contributors}}\
 \
-Welcome to the installer for the Xbox 360 Controller driver for Mac OS X.\
+Welcome to the installer for the Xbox 360 Controller driver for macOS.\
 
 \b \
 Update 0.16.7: 05/16/2018\
@@ -62,7 +63,7 @@ Update 0.16.6: 04/03/2018\
 \b0 \cf0 This update includes:\
 \pard\tx220\tx720\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\li720\fi-720\pardirnatural\partightenfactor0
 
-\b \cf0 	\'95	REMOVE XBOX 360 WIRELESS DRIVER
+\b \cf0 	\'95	REMOVED XBOX 360 WIRELESS DRIVER
 \b0 \
 	\'95	Enhancements for Bluetooth Xbox One S controllers\
 \pard\tx220\tx720\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\li720\fi-720\pardirnatural\partightenfactor0


### PR DESCRIPTION
Small updates to the installer texts: Fix missing space in Readme, refer to "macOS" instead of "Mac OS X", reflect 0.16.6's removal of support for wireless receiver, append copyright notice in Welcome.