### PR TITLE
Add PowerA Officially Licensed XBOX 360 controller

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -3753,6 +3753,26 @@
 			<key>idVendor</key>
 			<integer>9414</integer>
 		</dict>
+		<key>Xbox360ProEXController2</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>10271</integer>
+			<key>idVendor</key>
+			<integer>8406</integer>
+		</dict>
 		<key>XboxOneProEXController</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
This controller initially worked with the driver, when running on macOS 10.13.4, but does not currently work on 10.13.5

The controller is officially licensed by Microsoft and sold at Walmart.

PowerA Model 1414135-02 appears as follows in System Information > USB:

> Xbox 360 Pro Ex | *
> ----------------- | ----------
> Product ID | 0x281f
> Vendor ID | 0x20d6
> Version | 1.00
> Serial Number | 00000000
> Speed | Up to 12 Mb/sec
> Manufacturer | BDA
> Location ID | 0x14200000 / 11
> Current Available (mA) | 500
> Extra Operating Current (mA) | 0
