### PR TITLE
RockCandy Xbox One 2019 (Device from #909) is for Xbox One, not Xbox 360

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -3855,27 +3855,7 @@
 			<key>idVendor</key>
 			<integer>3695</integer>
 		</dict>
-		<key>RockCandyGamepadForXbox360 - 4</key>
-		<dict>
-			<key>CFBundleIdentifier</key>
-			<string>com.mice.driver.Xbox360Controller</string>
-			<key>IOCFPlugInTypes</key>
-			<dict>
-				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
-				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
-			</dict>
-			<key>IOClass</key>
-			<string>Xbox360Peripheral</string>
-			<key>IOKitDebug</key>
-			<integer>65535</integer>
-			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
-			<key>idProduct</key>
-			<integer>719</integer>
-			<key>idVendor</key>
-			<integer>3695</integer>
-		</dict>
-		<key>RockCandyGamepadforXboxOne2013</key>
+		<key>RockCandyGamepadForXboxOne2013</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
 			<string>com.mice.driver.Xbox360Controller</string>
@@ -3895,7 +3875,7 @@
 			<key>idVendor</key>
 			<integer>3695</integer>
 		</dict>
-		<key>RockCandyGamepadforXboxOne2015</key>
+		<key>RockCandyGamepadForXboxOne2015</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
 			<string>com.mice.driver.Xbox360Controller</string>
@@ -3915,7 +3895,7 @@
 			<key>idVendor</key>
 			<integer>3695</integer>
 		</dict>
-		<key>RockCandyGamepadforXboxOne2016</key>
+		<key>RockCandyGamepadForXboxOne2016</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
 			<string>com.mice.driver.Xbox360Controller</string>
@@ -3932,6 +3912,26 @@
 			<string>IOUSBDevice</string>
 			<key>idProduct</key>
 			<integer>838</integer>
+			<key>idVendor</key>
+			<integer>3695</integer>
+		</dict>
+		<key>RockCandyGamepadForXboxOne2019</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>719</integer>
 			<key>idVendor</key>
 			<integer>3695</integer>
 		</dict>


### PR DESCRIPTION
In this PR, I renamed the mislabeled device `RockCandyGamepadForXbox360 - 4` to `RockCandyGamepadForXboxOne2019`, moved it to the location of the other `RockCandyForXboxOne*` entries where it is chronologically sorted, and fixed the inconsistent PascalCasing.

Please note that this is my first PR to this codebase and if there is anything else that I need to do, let me know 🙂