### PR TITLE
Add known Hyperkin Duke controller IDs to driver.

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -1555,6 +1555,46 @@
 			<key>idVendor</key>
 			<integer>7085</integer>
 		</dict>
+		<key>HyperkinDuke</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBHostDevice</string>
+			<key>idProduct</key>
+			<integer>5656</integer>
+			<key>idVendor</key>
+			<integer>11812</integer>
+		</dict>
+		<key>HyperkinDuke2</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBHostDevice</string>
+			<key>idProduct</key>
+			<integer>1618</integer>
+			<key>idVendor</key>
+			<integer>11812</integer>
+		</dict>
 		<key>HyperkinX91</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
It appears the Hyperkin Duke's controller IDs were never mainlined into the driver so alpha.6 didn't include them. This change adds both known controller IDs for this device which should enable them to function in the next release. This should fix #1023  #932 and #949 