### PR TITLE
Adding a PowerA XboxOne controller using decimal values from the hex values.

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -655,6 +655,26 @@
 			<key>idVendor</key>
 			<integer>1390</integer>
 		</dict>
+		<key>PowerAXboxOne</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>8201</integer>
+			<key>idVendor</key>
+			<integer>8406</integer>
+		</dict>
 		<key>FUSIONProXboxOne</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Product ID: 0x2009 & Vendor ID: 0x20d6

Wired Xbox One Controller